### PR TITLE
Fixed compiler warnings and missing includes

### DIFF
--- a/src/wiic/balanceboard.c
+++ b/src/wiic/balanceboard.c
@@ -25,6 +25,8 @@
  *	$Header$
  *
  */
+#include <stdlib.h>
+
 #include "balanceboard.h"
 #include "events.h"
 

--- a/src/wiic/events.c
+++ b/src/wiic/events.c
@@ -55,6 +55,8 @@
 #include "classic.h"
 #include "guitar_hero_3.h"
 #include "events.h"
+#include "motionplus.h"
+#include "balanceboard.h"
 
 static void idle_cycle(struct wiimote_t* wm);
 void clear_dirty_reads(struct wiimote_t* wm);

--- a/src/wiic/motionplus.c
+++ b/src/wiic/motionplus.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <unistd.h>
 
 #include "definitions.h"
 #include "wiic_internal.h"
@@ -138,7 +139,7 @@ void motion_plus_apply_smoothing(struct motion_plus_t *mp)
  *
  *	@return	Returns 1 if handshake was successful, 0 if not.
  */
-int motion_plus_handshake(struct wiimote_t* wm, byte* data, unsigned short len) 
+void motion_plus_handshake(struct wiimote_t* wm, byte* data, unsigned short len)
 {
 	WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_EXP);
 	WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_EXP_FAILED);
@@ -178,10 +179,7 @@ int motion_plus_handshake(struct wiimote_t* wm, byte* data, unsigned short len)
 	else {
 		WIIC_ERROR("Unable to activate Motion Plus");
 		wiic_set_motion_plus(wm,0);
-		return 0;
 	}
-	
-	return 1;
 }
 
 /**

--- a/src/wiic/motionplus.h
+++ b/src/wiic/motionplus.h
@@ -42,7 +42,7 @@
 extern "C" {
 #endif
 
-int motion_plus_handshake(struct wiimote_t* wm, byte* data, unsigned short len);
+void motion_plus_handshake(struct wiimote_t* wm, byte* data, unsigned short len);
 
 void motion_plus_disconnected(struct motion_plus_t* mp);
 

--- a/src/wiic/speaker.c
+++ b/src/wiic/speaker.c
@@ -31,6 +31,8 @@
  *	@brief Handles the Wiimote speakers.
  */
 //#pragma pack(nopack)
+#include <unistd.h>
+
 #include "wiic_internal.h"
 #include "speaker.h"
 


### PR DESCRIPTION
Added some missing includes and changed the return type of `motion_plus_handshake` to void  to match
`wiic_read_cb`.
